### PR TITLE
expression_post_viz_transform.txt is exported outside output_dir

### DIFF
--- a/scripts/inferCNV.R
+++ b/scripts/inferCNV.R
@@ -506,8 +506,8 @@ write.table(ret_list["PREVIZ"], sep=args$delim,
                        "expression_pre_vis_transform.txt"))
 # Output data after viz outlier
 write.table(ret_list["VIZ"], sep=args$delim,
-            file=paste(args$output_dir,
-                       "expression_post_viz_transform.txt",sep="_"))
+            file=file.path(args$output_dir,
+                       "expression_post_viz_transform.txt"))
 logging::loginfo(paste("::infer_cnv:Current data dimensions (r,c)=",
                        paste(dim(ret_list[["VIZ"]]), collapse=","), sep=""))
 


### PR DESCRIPTION
**Problem**
The file *expression_post_viz_transform.txt* is exported outside `--output_dir` while the rest of the outputs are saved inside.

**What happend after thsi PR**
All the generated output files (without `--steps` turned on) are saved inside `--output_dir`.