### PR TITLE
Bioc: minor updates, sd_amplifier = 1 default

### DIFF
--- a/example/run.R
+++ b/example/run.R
@@ -12,11 +12,15 @@ infercnv_obj = CreateInfercnvObject(raw_counts_matrix="oligodendroglioma_express
 out_dir="output_dir"
 # perform infercnv operations to reveal cnv signal
 infercnv_obj = infercnv::run(infercnv_obj,
-                             cutoff=1, 
+                             cutoff=1, # cutoff=1 works well for Smart-seq2, and cutoff=0.1 works well for 10x Genomics
                              out_dir=out_dir, 
                              cluster_by_groups=T, 
                              plot_steps=T
                              )
+
+
+# save the final object in case we want to experiment with it later, replotting w/ diff thresholds, etc.
+save('infercnv_obj', file=file.path(out_dir, 'infercnv.final.obj'))
 
 # generate final plot
 plot_cnv(infercnv_obj,


### PR DESCRIPTION
minor updates. There was an issue when the smoothing was applied to a data set where there was just one gene left on the Y chr after filtering.  I set it to do smoothing on a chr when there's more than 1 gene there.  Also, the sd_amplifier is now 1 instead of 1.5 by default, which works better with the updated per-chr smoothing code.