### PR TITLE
bugfix impacting cell ordering in mulit-patient view

### DIFF
--- a/R/inferCNV.R
+++ b/R/inferCNV.R
@@ -377,3 +377,23 @@ validate_infercnv_obj <- function(infercnv_obj) {
 
 }
 
+
+get_cell_name_by_grouping <- function(infercnv_obj) {
+
+    cell_name_groupings = list()
+    
+    groupings = c(infercnv_obj@reference_grouped_cell_indices, infercnv_obj@observation_grouped_cell_indices)
+
+    for (group_name in names(groupings)) {
+
+        cell_names = colnames(infercnv_obj@expr.data[, groupings[[ group_name ]] ] )
+
+        cell_name_groupings[[ group_name ]] = cell_names
+
+    }
+
+    return(cell_name_groupings)
+}
+
+
+

--- a/R/inferCNV_heatmap.R
+++ b/R/inferCNV_heatmap.R
@@ -145,7 +145,8 @@ plot_cnv <- function(infercnv_obj,
     
     # Row separation based on reference
     ref_idx <- unlist(infercnv_obj@reference_grouped_cell_indices)
-
+    ref_idx = ref_idx[order(ref_idx)]
+        
     # Column seperation by contig and label axes with only one instance of name
     contig_tbl <- table(contigs)[unique_contigs]
     col_sep <- cumsum(contig_tbl)
@@ -176,13 +177,14 @@ plot_cnv <- function(infercnv_obj,
         counter <- counter + 1
     }
     # restrict to just the obs indices
-    obs_annotations_groups <- obs_annotations_groups[ unlist(obs_index_groupings) ]
-    
 
+    obs_annotations_groups <- obs_annotations_groups[-ref_idx]
+    
     grouping_key_coln[1] <- floor(123/(max(nchar(obs_annotations_names)) + 4))  ## 123 is the max width in number of characters, 4 is the space taken by the color box itself and the spacing around it
     if (grouping_key_coln[1] < 1) {
         grouping_key_coln[1] <- 1
     }
+
     name_ref_groups = names(infercnv_obj@reference_grouped_cell_indices)
     grouping_key_coln[2] <- floor(123/(max(nchar(name_ref_groups)) + 4))  ## 123 is the max width in number of characters, 4 is the space taken by the color box itself and the spacing around it
     if (grouping_key_coln[2] < 1) {
@@ -195,7 +197,7 @@ plot_cnv <- function(infercnv_obj,
     # Calculate how much bigger the output needs to be to accodomate for the grouping key
     grouping_key_height <- c((grouping_key_rown[2] + 2) * 0.175, (grouping_key_rown[1] + 3) * 0.175)
 
-                                        # Rows observations, Columns CHR
+    # Rows observations, Columns CHR
     if (! is.na(output_format)) {
         if (output_format == "pdf") {
             pdf(paste(out_dir, paste(output_filename, ".pdf", sep=""), sep="/"),
@@ -219,7 +221,7 @@ plot_cnv <- function(infercnv_obj,
     ## They are more informative anyway
     obs_data <- infercnv_obj@expr.data
     if (!is.null(ref_idx)){
-        obs_data <- plot_data[, -1 * ref_idx, drop=FALSE]
+        obs_data <- plot_data[, -ref_idx, drop=FALSE]
         if (ncol(obs_data) == 1) {
             # hack for dealing with single entries
             plot_data <- cbind(obs_data, obs_data)
@@ -244,7 +246,7 @@ plot_cnv <- function(infercnv_obj,
         current_grp_idx <- current_grp_idx + 1
     }
     ref_groups <- updated_ref_groups
-
+    
     nb_breaks <- 16
     breaksList_t <-
         seq(min(min(obs_data_t, na.rm=TRUE), min(ref_data_t, na.rm=TRUE)),

--- a/example/example.Rmd
+++ b/example/example.Rmd
@@ -292,8 +292,10 @@ plot_cnv(infercnv_obj,
 
 ```{r}
 knitr::include_graphics("infercnv.finalized_view.png")
+```
+
 And that's it. You can experiment with each step to fine-tune your data exploration.  See the documentation for uploading the resulting data matrix into the Next Generation Clustered Heatmap Viewer for more interactive exploration of the infercnv-processed data:
 <https://github.com/broadinstitute/inferCNV/wiki/Next-Generation-Clustered-Heat-Map>
 
 
-```
+


### PR DESCRIPTION

the  unlist(group indices) was breaking the synch between sample type labelings  and the cell names. Should be fixed here.