### PR TITLE
Use negative binomial for simulating spike-in

### DIFF
--- a/R/inferCNV_ops.R
+++ b/R/inferCNV_ops.R
@@ -1913,7 +1913,9 @@ anscombe_transform <- function(infercnv_obj) {
     
 }
 
-
+#' @keywords internal
+#' @noRd
+#'
 add_pseudocount <- function(infercnv_obj, pseudocount) {
 
     flog.info(sprintf("Adding pseudocount: %g", pseudocount))

--- a/R/inferCNV_ops.R
+++ b/R/inferCNV_ops.R
@@ -111,7 +111,7 @@ run <- function(infercnv_obj,
                 use_zscores=FALSE,
                 remove_genes_at_chr_ends=FALSE,
 
-                mask_nonDE_genes=TRUE,
+                mask_nonDE_genes=FALSE,
                 mask_nonDE_pval=0.05,
                 test.use='wilcoxon',
                 

--- a/R/inferCNV_spike.R
+++ b/R/inferCNV_spike.R
@@ -413,8 +413,10 @@ scale_cnv_by_spike <- function(infercnv_obj) {
     y = mean_p0_table$p0
 
     df = data.frame(x,y)
+
+    write.table(df, "_logistic_params", quote=F, sep="\t") 
     
-    fit <- nls(y ~ .logistic(x, midpt = x0, slope = k), data = df, start = list(x0 = 0, k = -1)) # borrow from splatter
+    fit <- nls(y ~ .logistic(x, midpt = x0, slope = k), data = df, start = list(x0 = mean(x), k = -1)) # borrowed/updated from splatter
     
     logistic_params = list()
 

--- a/R/inferCNV_spike.R
+++ b/R/inferCNV_spike.R
@@ -334,19 +334,31 @@ scale_cnv_by_spike <- function(infercnv_obj) {
     for (group_name in names(group_indices)) {
         flog.info(sprintf("processing group: %s", group_name))
         expr.data = infercnv_obj@expr.data[, group_indices[[ group_name ]] ]
-        ncells = ncol(expr.data)
-        m = rowMeans(expr.data)
-        numZeros = apply(expr.data, 1, function(x) { sum(x==0) })
 
-        pZero = numZeros/ncells
+        group_mean_p0_table <- .get_mean_vs_p0_from_matrix(expr.data)
+        group_mean_p0_table[[ 'group_name' ]] <- group_name
         
         if (is.null(mean_p0_table)) {
-            mean_p0_table = data.frame(g=group_name, m=m, p0=pZero)
+            mean_p0_table = group_mean_p0_table
         } else {
-            mean_p0_table = rbind(mean_p0_table, data.frame(g=group_name, m=m, p0=pZero))
+            mean_p0_table = rbind(mean_p0_table, group_mean_p0_table)
         }
     }
     
+    return(mean_p0_table)
+}
+
+
+
+.get_mean_vs_p0_from_matrix <- function(expr.data) {
+    ncells = ncol(expr.data)
+    m = rowMeans(expr.data)
+    numZeros = apply(expr.data, 1, function(x) { sum(x==0) })
+    
+    pZero = numZeros/ncells
+    
+    mean_p0_table = data.frame(m=m, p0=pZero)
+
     return(mean_p0_table)
 }
 

--- a/R/inferCNV_spike.R
+++ b/R/inferCNV_spike.R
@@ -393,7 +393,8 @@ scale_cnv_by_spike <- function(infercnv_obj) {
 #'
 #' @return Value of logistic function with given parameters
 #'
-#' @keywords internal                                                                                        #' @noRd
+#' @keywords internal
+#' @noRd
 #' 
 .logistic <- function(x, midpt, slope) {
     1 / (1 + exp(-slope * (x - midpt)))

--- a/R/inferCNV_spike.R
+++ b/R/inferCNV_spike.R
@@ -118,11 +118,9 @@ spike_in_variation_chrs <- function(infercnv_obj,
 ##' the mean/variance relationship for all genes in all cell groupings.
 ##'
 ##' Cells are simulated as so:
-##'    A random cell is selected from the normal cell expression matrix.
-##'    The expression of each gene is treated as a targeted mean expression value.
-##'    The variance is chosen based on a spline fit to the mean/variance relationship provided.
-##'    A random expression value is generated from a normal distribution with corresponding (mean, variance)
-##'
+##'    The mean for genes in the normal cells are computed
+##'    A random expression value is chosen for each gene using a negative binomial distribution with dispersion = 0.1
+##' 
 ##' Genes are named according to the input expression matrix, and cells are named 'spike_{number}'.
 ##' 
 ##' @param mean_var_table : a data.frame containing three columns: group_name, mean, variance of expression per gene per grouping.
@@ -166,6 +164,9 @@ spike_in_variation_chrs <- function(infercnv_obj,
     return(sim_cell_matrix)
 }
 
+##' @keywords internal
+##' @noRd
+##' 
 
 .sim_expr_val <- function(m,  dropout_logistic_params) {
     
@@ -220,7 +221,7 @@ spike_in_variation_chrs <- function(infercnv_obj,
     return(mean_var_table)
 }
 
-##' get_spike_in_average_bounds()
+##' .get_spike_in_average_bounds()
 ##'
 ##' return mean bounds for expression of all cells in the spike-in
 ##'
@@ -313,7 +314,11 @@ scale_cnv_by_spike <- function(infercnv_obj) {
 }
 
 
-# selects the specified number of chrs having the largest number of (expressed) genes
+#' selects the specified number of chrs having the largest number of (expressed) genes
+#' @keywords internal
+#' @noRd
+#' 
+
 .select_longest_chrs <- function(infercnv_obj, num_chrs_want) {
 
     # get count of chrs
@@ -323,7 +328,12 @@ scale_cnv_by_spike <- function(infercnv_obj) {
         
 }
 
-
+#' Computes probability of seeing a zero expr val as a function of the mean gene expression
+#' The p(0 | mean_expr) is computed separately for each sample grouping.
+#' 
+#' @keywords internal
+#' @noRd
+#' 
 
 .get_mean_vs_p0_table <- function(infercnv_obj) {
 
@@ -348,7 +358,12 @@ scale_cnv_by_spike <- function(infercnv_obj) {
     return(mean_p0_table)
 }
 
-
+#' Computes probability of seeing a zero expr val as a function of the mean gene expression
+#' based on the input expression  matrix.
+#' 
+#' @keywords internal
+#' @noRd
+#' 
 
 .get_mean_vs_p0_from_matrix <- function(expr.data) {
     ncells = ncol(expr.data)
@@ -381,6 +396,14 @@ scale_cnv_by_spike <- function(infercnv_obj) {
     1 / (1 + exp(-slope * (x - midpt)))
 }
 
+
+
+#' Given the mean, p0 table, fits the data to a logistic function to compute
+#' the shape of the logistic distribution.
+#' 
+#' @keywords internal
+#' @noRd
+#' 
 
 .get_logistic_params <- function(mean_p0_table) {
 

--- a/R/inferCNV_spike.R
+++ b/R/inferCNV_spike.R
@@ -268,7 +268,7 @@ remove_spike <- function(infercnv_obj) {
     return(infercnv_obj)
 
 }
-
+v
 
 
 #' scale_cnv_by_spike()
@@ -414,7 +414,7 @@ scale_cnv_by_spike <- function(infercnv_obj) {
 
     df = data.frame(x,y)
 
-    write.table(df, "_logistic_params", quote=F, sep="\t") 
+    #write.table(df, "_logistic_params", quote=F, sep="\t")  # debugging...
     
     fit <- nls(y ~ .logistic(x, midpt = x0, slope = k), data = df, start = list(x0 = mean(x), k = -1)) # borrowed/updated from splatter
     

--- a/R/inferCNV_spike.R
+++ b/R/inferCNV_spike.R
@@ -146,12 +146,13 @@ spike_in_variation_chrs <- function(infercnv_obj,
     
     sim_expr_val <- function(gene_idx, rand_cell_idx) {
         m = normal_cell_expr[gene_idx, rand_cell_idx]
-        v = predict(s, log2(m+1))$y
-        v = max(0, 2^v-1)
-        val = max(0, rnorm(n=1, mean=m, sd=sqrt(v)))
+        #v = predict(s, log2(m+1))$y
+        #v = max(0, 2^v-1)
+        #val = max(0, rnorm(n=1, mean=m, sd=sqrt(v)))
+        val = max(0, rnbinom(n=1, mu=m, size=0.1)) 
         return(val)
     }
-                  
+    
     sim_cell_matrix = matrix(rep(0,ngenes*num_cells), nrow=ngenes)
     rownames(sim_cell_matrix) = rownames(normal_cell_expr)
     colnames(sim_cell_matrix) = spike_cell_names

--- a/R/inferCNV_spike.R
+++ b/R/inferCNV_spike.R
@@ -268,7 +268,7 @@ remove_spike <- function(infercnv_obj) {
     return(infercnv_obj)
 
 }
-v
+
 
 
 #' scale_cnv_by_spike()
@@ -391,7 +391,7 @@ scale_cnv_by_spike <- function(infercnv_obj) {
 #' @param x0 midpoint parameter. Gives the centre of the function.
 #' @param k shape parameter. Gives the slope of the function.
 #'
-#' @return Value of logistic funciton with given parameters
+#' @return Value of logistic function with given parameters
 .logistic <- function(x, midpt, slope) {
     1 / (1 + exp(-slope * (x - midpt)))
 }

--- a/R/inferCNV_spike.R
+++ b/R/inferCNV_spike.R
@@ -392,6 +392,9 @@ scale_cnv_by_spike <- function(infercnv_obj) {
 #' @param k shape parameter. Gives the slope of the function.
 #'
 #' @return Value of logistic function with given parameters
+#'
+#' @keywords internal                                                                                        #' @noRd
+#' 
 .logistic <- function(x, midpt, slope) {
     1 / (1 + exp(-slope * (x - midpt)))
 }

--- a/example/example.Rmd
+++ b/example/example.Rmd
@@ -276,7 +276,6 @@ knitr::include_graphics("infercnv.non-DE-genes-masked.png")
 
 ```
 
-<<<<<<< HEAD
 ## Brighten it up by changing the scale threshold to our liking:
 
 ```{r}

--- a/example/run.R
+++ b/example/run.R
@@ -16,6 +16,7 @@ infercnv_obj = infercnv::run(infercnv_obj,
                              out_dir=out_dir, 
                              cluster_by_groups=T, 
                              plot_steps=F,
+                             mask_nonDE_genes = T,
                              include.spike=T  # used for final scaling to fit range (0,2) centered at 1.
                              )
 

--- a/scripts/examine_infercnv_data_params.R
+++ b/scripts/examine_infercnv_data_params.R
@@ -1,0 +1,82 @@
+#!/usr/bin/env Rscript
+
+args<-commandArgs(TRUE)
+
+if (length(args) == 0) {
+    stop("Error, require params: infercnv.obj");
+}
+
+infercnv_file_obj = args[1]
+
+load(infercnv_file_obj)
+
+
+infercnv_name_obj = grep("infercnv_obj", ls(), value=T)[1]
+
+print(infercnv_name_obj)
+
+infercnv_obj = get(infercnv_name_obj)
+
+
+library(edgeR)
+library(fitdistrplus)
+library(infercnv)
+
+# borrowing some code from splatter
+
+get_parameters <- function(group_name, expr.matrix) {
+
+    params = list()
+    params[['group_name']] = group_name
+    
+    # estimate gamma for  genes
+    lib.sizes <- colSums(expr.matrix)
+    lib.med <- median(lib.sizes)
+    norm.counts <- t(t(expr.matrix) / lib.sizes * lib.med)
+    norm.counts <- norm.counts[rowSums(norm.counts > 0) > 1, ]
+
+    means <- rowMeans(norm.counts)
+    means.fit <- fitdistrplus::fitdist(means, "gamma", method = "mme")
+    mean.shape = unname(means.fit$estimate["shape"])
+    mean.rate = unname(means.fit$estimate["rate"])
+
+    params[[ 'gamma.mean.shape' ]] = mean.shape
+    params[[ 'gamma.mean.rate' ]] = mean.rate
+    
+    
+    # estimate dropout params
+    mean_vs_p0_table = infercnv:::.get_mean_vs_p0_from_matrix(expr.matrix)
+    logistic_params = infercnv:::.get_logistic_params(mean_vs_p0_table)
+
+    params[['dropout.logistic.midpt']] = logistic_params$midpt
+    params[['dropout.logistic.slope']] = logistic_params$slope
+        
+    
+    # estimate common dispersion
+    design <- matrix(1, ncol(expr.matrix), 1)
+    disps <- edgeR::estimateDisp(expr.matrix, design = design)
+
+    params[[ 'common.dispersion' ]] = disps$common.dispersion
+    
+
+    return(params)
+
+}
+
+
+
+# examine each group
+all_groups = c(infercnv_obj@observation_grouped_cell_indices,  infercnv_obj@reference_grouped_cell_indices)
+
+for (group in names(all_groups)) {
+
+    group_idxs = all_groups[[ group ]]
+    expr.data = infercnv_obj@expr.data[,  group_idxs]
+
+    params = get_parameters(group, expr.data)
+    params = t(as.data.frame(params))
+    
+    print(params)
+    
+}
+


### PR DESCRIPTION
uses the negative binomial distribution for simulating spike-in including the logistic distribution for simulating dropouts (ala splatter).

Also, provides improved interface to the spike-in configuration via the run() method.