### PR TITLE
simple 3-state HMM included as alternative to the more complex 6-state

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,3 +32,4 @@ Collate:
     'inferCNV_tumor_subclusters.R'
     'inferCNV_tumor_subclusters.random_smoothed_trees.R'
     'noise_reduction.R'
+    'inferCNV_ZHMM.R'

--- a/R/inferCNV_HMM.R
+++ b/R/inferCNV_HMM.R
@@ -222,9 +222,7 @@ predict_CNV_via_HMM_on_indiv_cells  <- function(infercnv_obj, cnv_mean_sd=get_sp
 predict_CNV_via_HMM_on_tumor_subclusters  <- function(infercnv_obj,
                                                       cnv_mean_sd=get_spike_dists(infercnv_obj@.hspike),
                                                       cnv_level_to_mean_sd_fit=get_hspike_cnv_mean_sd_trend_by_num_cells_fit(infercnv_obj@.hspike),
-                                                      t=1e-6,
-                                                      p_val=0.05,
-                                                      hclust_method='ward.D2'
+                                                      t=1e-6
                                                       ) {
     
     

--- a/R/inferCNV_ZHMM.R
+++ b/R/inferCNV_ZHMM.R
@@ -10,27 +10,28 @@
 
     normal_samples = infercnv_obj@reference_grouped_cell_indices
     
-    expr_vals <- infercnv_obj@expr.data[,unlist(normal_samples)]
+    normal_expr_vals <- infercnv_obj@expr.data[,unlist(normal_samples)]
     
-    mu = mean(expr_vals)
-    sigma = sd(expr_vals)
+    mu = mean(normal_expr_vals)
+    sigma = sd(normal_expr_vals)
     nrounds = 100
     sds = c()
-    ngenes = nrow(expr_vals)
+    ngenes = nrow(normal_expr_vals)
 
     num_normal_samples = length(normal_samples)
-    
+    message("-got ", num_normal_samples, " samples") 
     for (ncells in seq_len(100)) {
         means = c()
         
         for(i in 1:nrounds) {
             ## pick a random gene
-            rand.gene = sample(1:ngenes)
+            rand.gene = sample(1:ngenes, size=1)
             
             ## pick a random normal cell type
-            rand.sample = sample(num_normal_samples)
+            rand.sample = sample(1:num_normal_samples, size=1)
+            #message("rand.sample: " , rand.sample)
             
-            vals = sample(expr_vals[rand.gene, normal_samples[[rand.sample]] ], size=ncells, replace=T)
+            vals = sample(infercnv_obj@expr.data[rand.gene, normal_samples[[rand.sample]] ], size=ncells, replace=T)
             m_val = mean(vals)
             means = c(means,  m_val)
         }

--- a/R/inferCNV_ZHMM.R
+++ b/R/inferCNV_ZHMM.R
@@ -1,0 +1,307 @@
+
+
+## Based on number of cells in a clade
+.ZHMM_get_normal_sd_trend_by_num_cells_fit <- function(infercnv_obj, z_p_val=0.05, plot=TRUE) {
+    
+    if (!has_reference_cells(infercnv_obj)) {
+        stop("Error, cannot tune parameters without reference 'normal' cells defined")
+    }
+
+
+    normal_samples = infercnv_obj@reference_grouped_cell_indices
+    
+    expr_vals <- infercnv_obj@expr.data[,unlist(normal_samples)]
+    
+    mu = mean(expr_vals)
+    sigma = sd(expr_vals)
+    nrounds = 100
+    sds = c()
+    ngenes = nrow(expr_vals)
+
+    num_normal_samples = length(normal_samples)
+    
+    for (ncells in seq_len(100)) {
+        means = c()
+        
+        for(i in 1:nrounds) {
+            ## pick a random gene
+            rand.gene = sample(1:ngenes)
+            
+            ## pick a random normal cell type
+            rand.sample = sample(num_normal_samples)
+            
+            vals = sample(expr_vals[rand.gene, normal_samples[[rand.sample]] ], size=ncells, replace=T)
+            m_val = mean(vals)
+            means = c(means,  m_val)
+        }
+        sds = c(sds, sd(means))
+    }
+    
+    ## fit linear model
+    num_cells = 1:length(sds)
+    fit = lm(log(sds) ~ log(num_cells)) #note, hbadger does something similar, but not for the hmm cnv state levels
+    
+    if (plot) {
+        plot(log(num_cells), log(sds), main='log(sd) vs. log(num_cells)')
+    }
+    
+    ## store mean_delta for the single gene for convenience sake
+    mean_delta = determine_mean_delta_via_Z(sigma, p=z_p_val)    
+
+    message("mean_delta: ", mean_delta, ", at sigma: ", sigma, ", and pval: ", z_p_val)
+    
+    normal_sd_trend = list(mu=mu,
+                           sigma=sigma,
+                           fit=fit,
+                           mean_delta=mean_delta)
+    
+    return(normal_sd_trend)
+    
+}
+
+
+.ZHMM_get_HMM <- function(normal_sd_trend, num_cells, t, z_p_val=0.05) {
+
+    ## Here we do something very similar to HoneyBadger
+    ## which is to estimate the mean/var for the CNV states
+    ## based on the KS statistic and the expression values
+    ## for the normal cells.
+    
+    
+    ##                      states: 0.5,    1,     1 .5
+    state_transitions = matrix( c(1-5*t,  t,     t,
+                                  t,     1-5*t,  t,
+                                  t,      t,     1-5*t),
+                               byrow=T,
+                               nrow=3)
+    
+    delta=c(t,     1-5*t,    t) # more likely normal,
+        
+    mu = normal_sd_trend$mu # normal cell mean
+    
+    if (num_cells == 1) {
+        sigma = normal_sd_trend$sigma
+        mean_delta = normal_sd_trend$mean_delta
+    } else {
+        ## use the var vs. num cells trend
+        sigma <- exp(predict(normal_sd_trend$fit,
+                             newdata=data.frame(num_cells=num_cells))[[1]])  
+
+        ## use t-test to determine adjusted mean value
+        
+     
+        #mean_delta <- determine_mean_delta_via_Z(sigma, p=z_p_val)
+
+        mean_delta = normal_sd_trend$mean_delta
+    }
+    
+    
+    state_emission_params = list(mean=c(
+                                     mu - mean_delta, # state 0.5 = deletion
+                                     mu, # state 1 = neutral
+                                     mu + mean_delta), # state 1.5 = amplification
+                                 
+                                 sd=c(sigma,
+                                      sigma,
+                                      sigma)  # shared variance as in HB
+                                 )
+    
+    HMM_info = list(state_transitions=state_transitions,
+                    delta=delta,
+                    state_emission_params=state_emission_params)
+    
+    return(HMM_info)
+}
+
+
+ZHMM_predict_CNV_via_HMM_on_indiv_cells  <- function(infercnv_obj,
+                                                     z_p_val=0.05,
+                                                     normal_sd_trend=.ZHMM_get_normal_sd_trend_by_num_cells_fit(infercnv_obj, z_p_val),
+                                                     t=1e-6) {
+    
+    flog.info("predict_CNV_via_HMM_on_indiv_cells()")
+    
+    chrs = unique(infercnv_obj@gene_order$chr)
+    
+    expr.data = infercnv_obj@expr.data
+    gene_order = infercnv_obj@gene_order
+    hmm.data = expr.data
+    hmm.data[,] = -1 #init to invalid state
+
+    HMM_info  <- .ZHMM_get_HMM(normal_sd_trend, num_cells = 1, t=t, z_p_val=z_p_val)
+
+    message(HMM_info)
+    
+    ## run through each chr separately
+    lapply(chrs, function(chr) {
+        chr_gene_idx = which(gene_order$chr == chr)
+        
+        ## run through each cell for this chromosome:
+        lapply(seq_len(ncol(expr.data)), function(cell_idx) {
+            
+            gene_expr_vals = as.vector(expr.data[chr_gene_idx,cell_idx])
+
+            hmm <- HiddenMarkov::dthmm(x=gene_expr_vals,
+                                       Pi=HMM_info[['state_transitions']],
+                                       delta=HMM_info[['delta']],
+                                       distn="norm",
+                                       pm=HMM_info[['state_emission_params']])
+            
+            
+            hmm_trace <- Viterbi.dthmm.adj(hmm)
+            
+            hmm.data[chr_gene_idx,cell_idx] <<- hmm_trace
+        })
+    })
+    
+    infercnv_obj@expr.data <- hmm.data
+    
+    return(infercnv_obj)
+    
+}
+            
+ZHMM_predict_CNV_via_HMM_on_tumor_subclusters  <- function(infercnv_obj,
+                                                           z_p_val=0.05,
+                                                           normal_sd_trend=.ZHMM_get_normal_sd_trend_by_num_cells_fit(infercnv_obj, z_p_val),
+                                                           t=1e-6
+                                                           ) {
+    
+    
+    flog.info(sprintf("ZHMM_predict_CNV_via_HMM_on_tumor_subclusters(z_p_val=%g)", z_p_val))
+
+    if (is.null(infercnv_obj@tumor_subclusters)) {
+        flog.warn("No subclusters defined, so instead running on whole samples")
+        return(ZHMM_predict_CNV_via_HMM_on_whole_tumor_samples(infercnv_obj, z_p_val, normal_sd_trend, t));
+    }
+    
+    
+    
+    chrs = unique(infercnv_obj@gene_order$chr)
+    
+    expr.data = infercnv_obj@expr.data
+    gene_order = infercnv_obj@gene_order
+    hmm.data = expr.data
+    hmm.data[,] = -1 #init to invalid state
+
+    tumor_subclusters <- unlist(infercnv_obj@tumor_subclusters[["subclusters"]], recursive=F)
+    
+    ## add the normals, so they get predictions too:
+    tumor_subclusters <- c(tumor_subclusters, infercnv_obj@reference_grouped_cell_indices)
+    
+    ## run through each chr separately
+    lapply(chrs, function(chr) {
+        chr_gene_idx = which(gene_order$chr == chr)
+        
+        ## run through each cell for this chromosome:
+        lapply(tumor_subclusters, function(tumor_subcluster_cells_idx) {
+            
+            gene_expr_vals = rowMeans(expr.data[chr_gene_idx,tumor_subcluster_cells_idx,drop=F])
+            
+            num_cells = length(tumor_subcluster_cells_idx)
+
+            HMM_info  <- .ZHMM_get_HMM(normal_sd_trend, num_cells=num_cells, t=t, z_p_val=z_p_val)
+                        
+                                    
+            hmm <- HiddenMarkov::dthmm(gene_expr_vals,
+                                       HMM_info[['state_transitions']],
+                                       HMM_info[['delta']],
+                                       "norm",
+                                       HMM_info[['state_emission_params']])
+            
+            ## hmm_trace <- HiddenMarkov::Viterbi(hmm)
+            hmm_trace <- Viterbi.dthmm.adj(hmm)
+            
+            hmm.data[chr_gene_idx,tumor_subcluster_cells_idx] <<- hmm_trace
+        })
+    })
+    
+    infercnv_obj@expr.data <- hmm.data
+
+    flog.info("-done predicting CNV based on initial tumor subclusters")
+        
+    return(infercnv_obj)
+    
+}
+
+
+
+ZHMM_predict_CNV_via_HMM_on_whole_tumor_samples  <- function(infercnv_obj,
+                                                        z_p_val=0.05,
+                                                        normal_sd_trend=.ZHMM_get_normal_sd_trend_by_num_cells_fit(infercnv_obj, z_p_val),
+                                                        t=1e-6
+                                                        ) {
+    
+    
+    flog.info("predict_CNV_via_HMM_on_whole_tumor_samples")
+    
+    
+    chrs = unique(infercnv_obj@gene_order$chr)
+    
+    expr.data = infercnv_obj@expr.data
+    gene_order = infercnv_obj@gene_order
+    hmm.data = expr.data
+    hmm.data[,] = -1 #init to invalid state
+
+    ## add the normals, so they get predictions too:
+    tumor_samples <- c(infercnv_obj@observation_grouped_cell_indices, infercnv_obj@reference_grouped_cell_indices)
+    
+    ## run through each chr separately
+    lapply(chrs, function(chr) {
+        chr_gene_idx = which(gene_order$chr == chr)
+        
+        ## run through each cell for this chromosome:
+        lapply(tumor_samples, function(tumor_sample_cells_idx) {
+            
+            gene_expr_vals = rowMeans(expr.data[chr_gene_idx,tumor_sample_cells_idx,drop=F])
+            
+            num_cells = length(tumor_sample_cells_idx)
+            
+            HMM_info  <- .ZHMM_get_HMM(normal_sd_trend, num_cells=num_cells, t=t, z_p_val=z_p_val)
+            
+            hmm <- HiddenMarkov::dthmm(gene_expr_vals,
+                                       HMM_info[['state_transitions']],
+                                       HMM_info[['delta']],
+                                       "norm",
+                                       HMM_info[['state_emission_params']])
+            
+            hmm_trace <- Viterbi.dthmm.adj(hmm)
+            
+            hmm.data[chr_gene_idx,tumor_sample_cells_idx] <<- hmm_trace
+        })
+    })
+    
+    infercnv_obj@expr.data <- hmm.data
+
+    flog.info("-done predicting CNV based on initial tumor subclusters")
+        
+    return(infercnv_obj)
+    
+}
+
+ZHMM_assign_HMM_states_to_proxy_expr_vals <- function(infercnv_obj) {
+    
+    expr.data = infercnv_obj@expr.data
+    
+    expr.data[expr.data == 1] <- 0.5
+    expr.data[expr.data == 2] <- 1
+    expr.data[expr.data == 3] <- 1.5
+    
+    infercnv_obj@expr.data <- expr.data
+
+    return(infercnv_obj)
+
+}
+
+
+determine_mean_delta_via_Z <- function(sigma, p) {
+    
+    ## want tails of the distribution to minimially overlap at the p-value
+    
+    delta = abs(qnorm(p=p, mean=0, sd=sigma)) 
+
+    flog.info(sprintf("determine mean delta (sigma: %g, p=%g) -> %g", sigma, p, delta))
+    
+    return(2 * delta)
+    
+}
+

--- a/R/inferCNV_ops.R
+++ b/R/inferCNV_ops.R
@@ -265,7 +265,10 @@ run <- function(infercnv_obj,
     step_count = step_count + 1
     flog.info(sprintf("\n\n\tSTEP %02d: normalization by sequencing depth\n", step_count))
 
-    infercnv_obj_file = file=file.path(out_dir, sprintf("%02d_normalized_by_depth.infercnv_obj", step_count))
+
+    resume_file_token = ifelse(HMM, ".wHspike", "")
+    
+    infercnv_obj_file = file=file.path(out_dir, sprintf("%02d_normalized_by_depth%s.infercnv_obj", step_count, resume_file_token))
 
     if (reuse_subtracted && file.exists(infercnv_obj_file)) {
         flog.info(sprintf("-restoring infercnv_obj from %s", infercnv_obj_file))
@@ -274,13 +277,15 @@ run <- function(infercnv_obj,
     } else {
         infercnv_obj <- normalize_counts_by_seq_depth(infercnv_obj)
 
-        # add in the hidden spike needed by the HMM
-        infercnv_obj <- .build_and_add_hspike(infercnv_obj, sim_method=sim_method, aggregate_normals=hspike_aggregate_normals)
-        
-        if (sim_foreground) {
-            infercnv_obj <- .sim_foreground(infercnv_obj, sim_method=sim_method)
+        if (HMM) {
+            ## add in the hidden spike needed by the HMM
+            infercnv_obj <- .build_and_add_hspike(infercnv_obj, sim_method=sim_method, aggregate_normals=hspike_aggregate_normals)
+            
+            if (sim_foreground) {
+                infercnv_obj <- .sim_foreground(infercnv_obj, sim_method=sim_method)
+            }
         }
-
+        
         saveRDS(infercnv_obj, infercnv_obj_file)
     }
 
@@ -291,7 +296,7 @@ run <- function(infercnv_obj,
     step_count = step_count + 1
     flog.info(sprintf("\n\n\tSTEP %02d: log transformation of data\n", step_count))
 
-    infercnv_obj_file = file.path(out_dir, sprintf("%02d_logtransformed.infercnv_obj", step_count))
+    infercnv_obj_file = file.path(out_dir, sprintf("%02d_logtransformed%s.infercnv_obj", step_count, resume_file_token))
 
     if (reuse_subtracted && file.exists(infercnv_obj_file)) {
         flog.info(sprintf("-restoring infercnv_obj from %s", infercnv_obj_file))
@@ -331,7 +336,7 @@ run <- function(infercnv_obj,
         step_count = step_count + 1
         flog.info(sprintf("\n\n\tSTEP %02d: splitting reference data into %d clusters\n", step_count, num_ref_groups))
 
-        infercnv_obj_file = file.path(out_dir, sprintf("%02d_split_%02d_refs.infercnv_obj", step_count, num_ref_groups))
+        infercnv_obj_file = file.path(out_dir, sprintf("%02d_split_%02d_refs%s.infercnv_obj", step_count, resume_file_token, num_ref_groups))
 
         if (reuse_subtracted && file.exists(infercnv_obj_file)) {
             flog.info(sprintf("-restoring infercnv_obj from %s", infercnv_obj_file))
@@ -352,7 +357,8 @@ run <- function(infercnv_obj,
         step_count = step_count + 1
         flog.info(sprintf("\n\n\tSTEP %02d: computing tumor subclusters via %s\n", step_count, tumor_subcluster_partition_method))
 
-        infercnv_obj_file = file.path(out_dir, sprintf("%02d_tumor_subclusters.%s.infercnv_obj", step_count, tumor_subcluster_partition_method))
+        resume_file_token = paste0(resume_file_token, ".rand_trees")
+        infercnv_obj_file = file.path(out_dir, sprintf("%02d_tumor_subclusters%s.%s.infercnv_obj", step_count, resume_file_token, tumor_subcluster_partition_method))
         
         if (reuse_subtracted && file.exists(infercnv_obj_file)) {
             flog.info(sprintf("-restoring infercnv_obj from %s", infercnv_obj_file))
@@ -389,7 +395,7 @@ run <- function(infercnv_obj,
     flog.info(sprintf("\n\n\tSTEP %02d: removing average of reference data (before smoothing)\n", step_count))
 
     infercnv_obj_file = file.path(out_dir,
-                                  sprintf("%02d_remove_ref_avg_from_obs_logFC.infercnv_obj", step_count))
+                                  sprintf("%02d_remove_ref_avg_from_obs_logFC%s.infercnv_obj", step_count, resume_file_token))
 
     if (reuse_subtracted && file.exists(infercnv_obj_file)) {
         flog.info(sprintf("-restoring infercnv_obj from %s", infercnv_obj_file))
@@ -420,7 +426,7 @@ run <- function(infercnv_obj,
         step_count = step_count + 1
         flog.info(sprintf("\n\n\tSTEP %02d: apply max centered expression threshold: %s\n", step_count, max_centered_threshold))
 
-        infercnv_obj_file=file.path(out_dir, sprintf("%02d_apply_max_centered_expr_threshold.infercnv_obj", step_count))
+        infercnv_obj_file=file.path(out_dir, sprintf("%02d_apply_max_centered_expr_threshold%s.infercnv_obj", step_count, resume_file_token))
 
         if (reuse_subtracted && file.exists(infercnv_obj_file)) {
             flog.info(sprintf("-restoring infercnv_obj from %s", infercnv_obj_file))
@@ -465,7 +471,7 @@ run <- function(infercnv_obj,
     step_count = step_count + 1
     flog.info(sprintf("\n\n\tSTEP %02d: Smoothing data per cell by chromosome\n", step_count))
 
-    infercnv_obj_file = file.path(out_dir, sprintf("%02d_smoothed_by_chr.infercnv_obj", step_count))
+    infercnv_obj_file = file.path(out_dir, sprintf("%02d_smoothed_by_chr%s.infercnv_obj", step_count, resume_file_token))
 
     if (reuse_subtracted && file.exists(infercnv_obj_file)) {
         flog.info(sprintf("-restoring infercnv_obj from %s", infercnv_obj_file))
@@ -506,7 +512,7 @@ run <- function(infercnv_obj,
     step_count = step_count + 1
     flog.info(sprintf("\n\n\tSTEP %02d: re-centering data across chromosome after smoothing\n", step_count))
 
-    infercnv_obj_file = file.path(out_dir, sprintf("%02d_recentered_cells_by_chr.infercnv_obj", step_count))
+    infercnv_obj_file = file.path(out_dir, sprintf("%02d_recentered_cells_by_chr%s.infercnv_obj", step_count, resume_file_token))
     if (reuse_subtracted && file.exists(infercnv_obj_file)) {
         flog.info(sprintf("-restoring infercnv_obj from %s", infercnv_obj_file))
         infercnv_obj <- readRDS(infercnv_obj_file)
@@ -538,7 +544,7 @@ run <- function(infercnv_obj,
     flog.info(sprintf("\n\n\tSTEP %02d: removing average of reference data (after smoothing)\n", step_count))
 
     infercnv_obj_file = file.path(out_dir,
-                           sprintf("%02d_remove_ref_avg_from_obs_adjust.infercnv_obj", step_count))
+                           sprintf("%02d_remove_ref_avg_from_obs_adjust%s.infercnv_obj", step_count, resume_file_token))
 
     if (reuse_subtracted && file.exists(infercnv_obj_file)) {
         flog.info(sprintf("-restoring infercnv_obj from %s", infercnv_obj_file))
@@ -567,7 +573,7 @@ run <- function(infercnv_obj,
         step_count = step_count + 1
         flog.info(sprintf("\n\n\tSTEP %02d: removing genes at chr ends\n", step_count))
 
-        infercnv_obj_file = file.path(out_dir, sprintf("%02d_remove_gene_at_chr_ends.infercnv_obj", step_count))
+        infercnv_obj_file = file.path(out_dir, sprintf("%02d_remove_gene_at_chr_ends%s.infercnv_obj", step_count, resume_file_token))
 
         if (reuse_subtracted && file.exists(infercnv_obj_file)) {
             flog.info(sprintf("-restoring infercnv_obj from %s", infercnv_obj_file))
@@ -600,7 +606,7 @@ run <- function(infercnv_obj,
         step_count = step_count + 1
         flog.info(sprintf("\n\n\tSTEP %02d: invert log2(FC) to FC\n", step_count))
 
-        infercnv_obj_file = file.path(out_dir, sprintf("%02d_invert_log_transform.infercnv_obj", step_count))
+        infercnv_obj_file = file.path(out_dir, sprintf("%02d_invert_log_transform%s.infercnv_obj", step_count, resume_file_token))
 
         if (reuse_subtracted && file.exists(infercnv_obj_file)) {
             flog.info(sprintf("-restoring infercnv_obj from %s", infercnv_obj_file))
@@ -630,10 +636,12 @@ run <- function(infercnv_obj,
 
     if (HMM_mode == 'subclusters' & tumor_subcluster_partition_method != 'random_trees') {
 
+        resume_file_token = paste0(resume_file_token, '.', tumor_subcluster_partition_method)
+        
         step_count = step_count + 1
         flog.info(sprintf("\n\n\tSTEP %02d: computing tumor subclusters via %s\n", step_count, tumor_subcluster_partition_method))
 
-        infercnv_obj_file = file.path(out_dir, sprintf("%02d_tumor_subclusters.%s.infercnv_obj", step_count, tumor_subcluster_partition_method))
+        infercnv_obj_file = file.path(out_dir, sprintf("%02d_tumor_subclusters%s.infercnv_obj", step_count, resume_file_token))
 
         infercnv_obj <- define_signif_tumor_subclusters(infercnv_obj,
                                                         p_val=tumor_subcluster_pval,
@@ -719,8 +727,10 @@ run <- function(infercnv_obj,
         ## ##################################
         ## Note, HMM invercnv object is only leveraged here, but stored as file for future use:
         ## ##################################
+
+        hmm_resume_file_token = paste0(resume_file_token, ".hmm_mode-", HMM_mode)
         
-        hmm.infercnv_obj_file = file.path(out_dir, sprintf("%02d_HMM_pred.infercnv_obj", step_count))
+        hmm.infercnv_obj_file = file.path(out_dir, sprintf("%02d_HMM_pred%s.infercnv_obj", step_count, hmm_resume_file_token))
         saveRDS(hmm.infercnv_obj, file=hmm.infercnv_obj_file)
         
         ## report predicted cnv regions:
@@ -755,7 +765,7 @@ run <- function(infercnv_obj,
         
         hmm.infercnv_obj <- assign_HMM_states_to_proxy_expr_vals(hmm.infercnv_obj)
         
-        hmm.infercnv_obj_file = file.path(out_dir, sprintf("%02d_HMM_pred.repr_intensities.infercnv_obj", step_count))
+        hmm.infercnv_obj_file = file.path(out_dir, sprintf("%02d_HMM_pred.repr_intensities%s.infercnv_obj", step_count, hmm_resume_file_token))
         saveRDS(hmm.infercnv_obj, file=hmm.infercnv_obj_file)
         
         ## Plot HMM pred img
@@ -788,7 +798,7 @@ run <- function(infercnv_obj,
                                                 require_DE_all_normals=require_DE_all_normals)
         
         saveRDS(infercnv_obj,
-                file=file.path(out_dir, sprintf("%02d_mask_nonDE.infercnv_obj", step_count)))
+                file=file.path(out_dir, sprintf("%02d_mask_nonDE%s.infercnv_obj", step_count, resume_file_token)))
         
         ## Plot incremental steps.
         if (plot_steps) {
@@ -836,7 +846,7 @@ run <- function(infercnv_obj,
         }
         
         saveRDS(infercnv_obj,
-                file=file.path(out_dir, sprintf("%02d_denoise.infercnv_obj", step_count)))
+                file=file.path(out_dir, sprintf("%02d_denoise%s.infercnv_obj", step_count, resume_file_token)))
         
         
         plot_cnv(infercnv_obj,

--- a/scripts/examine_normal_sampling_distributions.R
+++ b/scripts/examine_normal_sampling_distributions.R
@@ -1,0 +1,147 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages(library("argparse"))
+    
+parser = ArgumentParser()
+parser$add_argument("--infercnv_obj", help="infercnv_obj file", required=TRUE, nargs=1)
+args = parser$parse_args()
+
+library(infercnv)
+library(tidyverse)
+library(futile.logger)
+
+infercnv_obj_file = args$infercnv_obj
+
+infercnv_obj = readRDS(infercnv_obj_file)
+
+if (! infercnv:::has_reference_cells(infercnv_obj)) {
+    stop("Error, cannot tune parameters without reference 'normal' cells defined")
+}
+
+expr_vals <- infercnv_obj@expr.data
+mu = mean(expr_vals)
+sigma = sd(expr_vals)
+nrounds = 1000
+sds = c()
+ngenes = nrow(expr_vals)
+
+normal_samples = infercnv_obj@reference_grouped_cell_indices
+
+num_normal_samples = length(normal_samples)
+
+mean_vals_df = NULL;
+z_p_val = 0.05
+
+num_cells_to_empirical_sd = list()
+
+ncells_partitions = seq (1,100,5)
+for (ncells in ncells_partitions) {
+    means = c()
+    
+    message(sprintf("num cells: %g", ncells))
+
+    cells_counted = 0;
+    
+    for(i in 1:nrounds) {
+        ## pick a random gene
+        rand.gene = sample(1:ngenes)
+        
+        ## pick a random normal cell type
+        rand.sample = sample(num_normal_samples)
+        #rand.sample=1
+        
+        vals = sample(expr_vals[rand.gene, normal_samples[[rand.sample]] ], size=ncells, replace=T)
+        m_val = mean(vals)
+        means = c(means,  m_val)
+
+        cells_counted = cells_counted + length(vals)
+
+        
+    }
+    my.sd = sd(means)
+    sds = c(sds, my.sd)
+
+    num_cells_to_empirical_sd[[ ncells ]] = my.sd
+    
+    df = data.frame(num_cells=ncells, vals=means)
+                                        #print(df)
+    if(is.null(mean_vals_df)) {
+        mean_vals_df = df
+    } else {
+        mean_vals_df = rbind(mean_vals_df, df)
+    }
+    
+}
+
+## fit linear model
+num_cells = ncells_partitions
+
+write.table(data.frame(num_cells=num_cells, sds=sds), file='num_cells_vs_sds.table.dat', quote=F, sep="\t")
+
+
+fit = lm(log(sds) ~ log(num_cells)) #note, hbadger does something similar, but not for the hmm cnv state levels
+
+my.spline = smooth.spline(log(num_cells), log(sds)) 
+
+message("plotting log(sd) vs. log(num_cells)")
+
+plot(log(num_cells), log(sds), main='log(sd) vs. log(num_cells)')
+
+plot(num_cells, sds, main='sd vs. num_cells')
+
+my.spline2 = smooth.spline(num_cells, sds) 
+
+## store mean_delta for the single gene for convenience sake
+mean_delta = qnorm(p=1-z_p_val, sd=sigma, mean=0)
+
+normal_sd_trend = list(mu=mu,
+                       sigma=sigma,
+                       fit=fit,
+                       spline=my.spline,
+                       mean_delta=mean_delta)
+
+
+
+### do some plotting
+
+
+for (ncells in ncells_partitions) {
+
+    message(sprintf("plotting ncells distribution: %g", ncells))
+    
+    data.want = mean_vals_df %>% filter(num_cells == ncells)
+    
+    
+    p = data.want %>% ggplot(aes(vals, fill=num_cells)) +
+        geom_density(alpha=0.3)
+
+    sigma <- exp(predict(normal_sd_trend$fit,
+                         newdata=data.frame(num_cells=ncells))[[1]]) 
+    
+    p = p +
+        stat_function(fun=dnorm, color='black', args=list('mean'=1,'sd'=sigma))  +
+        ggtitle(sprintf("num_cells: %g, sd: %g", ncells, sigma))
+
+    p = p +
+        stat_function(fun=dnorm, color='magenta', args=list('mean'=1,'sd'=num_cells_to_empirical_sd[[ ncells]] )) 
+    
+
+    if (FALSE) {
+    
+        spline.sd = exp(predict(my.spline, x=log(ncells))$y)
+        
+        
+        p = p +
+            stat_function(fun=dnorm, color='green', args=list('mean'=1,'sd'=spline.sd)) 
+        
+        spline2.sd = predict(my.spline2, x=ncells)$y
+        
+        message(spline2.sd)
+        
+        p = p +
+            stat_function(fun=dnorm, color='orange', args=list('mean'=1,'sd'=spline2.sd)) 
+    }
+    
+    plot(p)
+}
+

--- a/scripts/examine_normal_sampling_distributions.R
+++ b/scripts/examine_normal_sampling_distributions.R
@@ -117,6 +117,8 @@ for (ncells in ncells_partitions) {
 
     sigma <- exp(predict(normal_sd_trend$fit,
                          newdata=data.frame(num_cells=ncells))[[1]]) 
+
+    message("ncells:", ncells, " sigma: ", sigma)
     
     p = p +
         stat_function(fun=dnorm, color='black', args=list('mean'=1,'sd'=sigma))  +
@@ -124,6 +126,23 @@ for (ncells in ncells_partitions) {
 
     p = p +
         stat_function(fun=dnorm, color='magenta', args=list('mean'=1,'sd'=num_cells_to_empirical_sd[[ ncells]] )) 
+
+
+    pval=0.01
+    
+    left_mean = 1 - 2 * (1-qnorm(p=pval, mean=1, sd=sigma))
+    message("left_mean: ", left_mean)
+    p = p +
+        stat_function(fun=dnorm, color='blue', args=list('mean'=left_mean,'sd'=sigma))
+
+
+    right_mean = 1 + 2 * (qnorm(p=1-pval, mean=1, sd=sigma)-1)
+    message("right_mean: ", right_mean)        
+        p = p +
+            stat_function(fun=dnorm, color='blue', args=list('mean'=right_mean,'sd'=sigma))  
+    
+    
+
     
 
     if (FALSE) {


### PR DESCRIPTION
there's now a parameter:  HMM_type = c('i6', 'i3') where, by default, it uses the 6-state HMM that leverages simulation for calibrating CNV levels.  The new 'i3' method is simulation free and defines emissions for amp/del based on minimally overlapping distributions to the neutral type as defined by the normal cells - which seems to work well.  Default is 'i6'.

The HMM_mode is now 'analysis_mode', since it defines cell clustering methods to use which apply to both the image filtering and to the HMM predictions.

Also re-introduced the scaling method, which is useful when GTEx normals are used as the normal data sets and their dynamic range differs greatly from single cell data explored in the tumor samples.