### PR TITLE
Parallelize get_predicted_CNV_regions 

### DIFF
--- a/R/inferCNV_HMM.R
+++ b/R/inferCNV_HMM.R
@@ -653,56 +653,43 @@ get_predicted_CNV_regions <- function(infercnv_obj, by=c("consensus", "subcluste
     state_par_func <- function(i){
         cell_group_name = cell_group_names[[i]]
         cell_group = cell_groups[[cell_group_name]]
-        flog.info(sprintf("-processing (pass 1/2) cell_group_name: %s, size: %d",
+        flog.info(sprintf("-processing cell_group_name: %s, size: %d",
                           cell_group_name, length(cell_group)))
 
         cell_group_mtx = infercnv_obj@expr.data[,cell_group,drop=FALSE]
 
         state_consensus <- .get_state_consensus(cell_group_mtx)
-        
+
         names(state_consensus) <- rownames(cell_group_mtx)
-        num_cnvs <- .get_num_cnv_gene_regions(state_consensus, infercnv_obj@gene_order)
-        consensus_state_list = list(state_consensus=state_consensus,
-                                    cell_group_names_from_mtx=colnames(cell_group_mtx),
-                                    num_cnvs=num_cnvs)
-        consensus_state_list
-     }
-
-    state_return_obj <- parallel::mclapply(seq_along(cell_groups),
-                                           FUN = state_par_func,
-                                           mc.cores = mc.cores)
-
-    # calculate the unique identifier for region names using a counter
-    cnv_counter_pos = list()
-    cnv_counter_start = 0
-    for (i in 1:num_cell_groups) {
-        cnv_counter_pos[[i]] = cnv_counter_start
-        cnv_counter_start = cnv_counter_start + state_return_obj[[i]]$num_cnvs
-    }
-
-    regions_par_func <- function(i){
-        cell_group_name = cell_group_names[[i]]
-        flog.info(sprintf("-processing (pass 2/2) cell_group_name: %s, size: %d",
-                          cell_group_name, length(cell_groups[[cell_group_name]])))
-        cnv_gene_regions <- .define_cnv_gene_regions(state_return_obj[[i]]$state_consensus,
-                                                     infercnv_obj@gene_order,
-                                                     cnv_counter_pos[[i]])
-        cnv_ranges <- .get_cnv_gene_region_bounds(cnv_gene_regions)
+        cnv_gene_regions <- .define_cnv_gene_regions(state_consensus,
+                                                     infercnv_obj@gene_order)
 
         cnv_region_list = list(cell_group_name=cell_group_name,
-                                    cells=state_return_obj[[i]]$cell_group_names_from_mtx,
-                                    gene_regions=cnv_gene_regions,
-                                    cnv_ranges=cnv_ranges)
+                               cells=colnames(cell_group_mtx),
+                               gene_regions=cnv_gene_regions)
         cnv_region_list
+
+     }
+
+    unnamed_cnv_regions <- parallel::mclapply(seq_along(cell_groups),
+                                              FUN = state_par_func,
+                                              mc.cores = mc.cores)
+
+    # updates regions with unique name
+    named_cnv_regions = list()
+    cnv_counter_start = 0
+    for (i in 1:num_cell_groups) {
+        cnv_gene_regions <- .rename_cnv_gene_regions(unnamed_cnv_regions[[i]]$gene_regions, cnv_counter_start)
+        cnv_counter_start = cnv_counter_start + length(cnv_gene_regions)
+        cnv_ranges <- .get_cnv_gene_region_bounds(cnv_gene_regions)
+
+        named_cnv_regions[[i]] = list(cell_group_name=unnamed_cnv_regions[[i]]$cell_group_name,
+                               cells=unnamed_cnv_regions[[i]]$cells,
+                               gene_regions=cnv_gene_regions,
+                               cnv_ranges=cnv_ranges)
     }
-
-    cnv_regions <- parallel::mclapply(seq_along(cell_groups),
-                                      FUN = regions_par_func,
-                                      mc.cores = mc.cores)
-
-        
     
-    return(cnv_regions)
+    return(named_cnv_regions)
     
 }
 
@@ -969,24 +956,50 @@ adjust_genes_regions_report <- function(hmm.infercnv_obj,
     return(cnv_region_counter)
 }
 
-#' @title .define_cnv_gene_regions
+#' @title .rename_cnv_gene_regions
 #'
-#' @description Given the state consensus vector and gene order info, defines cnv regions
-#' based on consistent ordering and cnv state 
+#' @description Rename cnv regions with global consistent names
 #'
-#' @param state_consensus state consensus vector
+#' @param unnamed_regions list of regions returned by .define_cnv_gene_regions
 #'
-#' @param gene_order the infercnv_obj@gene_order info
-#'
-#' @param cnv_region_counter number x where counting starts at x+1, used to provide unique region names.
+#' @param cnv_counter_start starting index of cnv counter
 #'
 #' @return regions  list containing the cnv regions defined.
 #'
 #' @noRd
 
-.define_cnv_gene_regions <- function(state_consensus, gene_order, cnv_region_counter) {
+.rename_cnv_gene_regions <- function(unnamed_regions, cnv_counter_start) {
 
-    regions = list()
+    named_regions = list()
+
+    for (ii in seq_along(unnamed_regions)) {
+        chr = as.character(unnamed_regions[[ii]]$chr)[1]
+        cnv_index = cnv_counter_start + ii
+        cnv_region_name = sprintf("%s-region_%d", chr, cnv_index)
+        named_regions[[cnv_region_name]] = unnamed_regions[[ii]]
+    }
+
+    return(named_regions)
+}
+
+#' @title .define_cnv_gene_regions
+#'
+#' @description Given the state consensus vector and gene order info, defines cnv regions
+#' based on local ordering and cnv state
+#'
+#' @param state_consensus state consensus vector
+#'
+#' @param gene_order the infercnv_obj@gene_order info
+#'
+#' @return regions  list containing the cnv regions defined.
+#'
+#' @noRd
+
+.define_cnv_gene_regions <- function(state_consensus, gene_order) {
+
+    unnamed_regions = list()
+
+    local_cnv_region_counter = 0
 
     gene_names = rownames(gene_order)
     
@@ -1000,15 +1013,14 @@ adjust_genes_regions_report <- function(hmm.infercnv_obj,
         ## pos_begin = paste(gene_order[gene_idx[1],,drop=TRUE], collapse=",")
         pos_begin = gene_order[gene_idx[1],,drop=TRUE]
         
-        cnv_region_counter = cnv_region_counter + 1
+        local_cnv_region_counter = local_cnv_region_counter + 1
 
-        cnv_region_name = sprintf("%s-region_%d", chr, cnv_region_counter)
         current_cnv_region = data.frame(state=prev_state,
                                         gene=gene_names[gene_idx[1]],
                                         chr=pos_begin$chr,
                                         start=pos_begin$start,
                                         end=pos_begin$stop) 
-        regions[[cnv_region_name]] = current_cnv_region
+        unnamed_regions[[local_cnv_region_counter]] = current_cnv_region
         
         for (i in seq(2,length(gene_idx))) {
             state = chr_states[i]
@@ -1022,12 +1034,11 @@ adjust_genes_regions_report <- function(hmm.infercnv_obj,
             if (state != prev_state) {
                 ## state transition
                 ## start new cnv region
-                cnv_region_counter = cnv_region_counter + 1
-                cnv_region_name = sprintf("%s-region_%d", chr, cnv_region_counter)
-                regions[[cnv_region_name]] = next_gene_entry
+                cnv_regionlocal_cnv_region_counter_counter = local_cnv_region_counter + 1
+                unnamed_regions[[local_cnv_region_counter]] = next_gene_entry
             } else {
                 ## append gene to current cnv region
-                regions[[cnv_region_name]] = rbind(regions[[cnv_region_name]], next_gene_entry)
+                unnamed_regions[[local_cnv_region_counter]] = rbind(unnamed_regions[[local_cnv_region_counter]], next_gene_entry)
             }
 
             prev_state = state
@@ -1035,7 +1046,7 @@ adjust_genes_regions_report <- function(hmm.infercnv_obj,
         
     }
 
-    return(regions)
+    return(unnamed_regions)
 }
 
 


### PR DESCRIPTION
When running with `HMM_report_by='cell'`, the time spent in `get_predicted_CNV_regions` dominates total runtime as each cell is processed sequentially. This pull request parallelizes the bulk of the loop to speed up runtime.  When the number of cells is over 10k, this can reduce the runtime from days to hours.

The `parallel` framework was used because it is already imported in `inferCNV_BayesNet.R`. `mclapply` parallelizes the loop over the number of cores specifed by `num_threads` when `infercnv::run()` is called.

Note that parallel refactoring was complicated by the counter variable that ensures unique names for cnv regions. The workaround was to assign the region names in a loop at the end, after parallel execution. This has the same effect as incrementing a counter, but means that the call to `.get_cnv_gene_region_bounds` must be placed outside the parallel loop. The function is simple enough that running it on a single core won't significantly delay overall runtime.